### PR TITLE
Change field level in metadata

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -36,7 +36,7 @@ A frictionless datapackage consits of a JSON, describing one or more tabular dat
 !echemdbconverters csv ../test/csv/default.csv --outdir ../test/generated
 ```
 
-By providing information on the units of the columns in a metadata file (YAML) a [unitpackage](https://github.com/echemdb/unitpackage) can be created. The units to the columns must be included in the YAML under `figure_description.schema.fields`, according to the [frictionless field schema](https://specs.frictionlessdata.io/table-schema/#field-descriptors). See {download}`example YAML <../test/csv/unit.csv.metadata>` for reference.
+By providing information on the units of the columns in a metadata file (YAML) a [unitpackage](https://github.com/echemdb/unitpackage) can be created. The units to the columns must be included in the YAML under `figure_description.fields`, according to the [frictionless field schema](https://specs.frictionlessdata.io/table-schema/#field-descriptors). See {download}`example YAML <../test/csv/unit.csv.metadata>` for reference.
 
 ```{code-cell} ipython3
 !echemdbconverters csv ../test/csv/unit.csv --metadata ../test/csv/unit.csv.metadata --outdir ../test/generated

--- a/doc/news/fieldnesting.rst
+++ b/doc/news/fieldnesting.rst
@@ -1,0 +1,3 @@
+**Changed:**
+
+* Changed inferring fields from metadata in the CLI from `figure_description.schema.fields` to `figure_description.fields`.

--- a/echemdbconverters/csvloader.py
+++ b/echemdbconverters/csvloader.py
@@ -308,9 +308,9 @@ class CSVloader:
             >>> file = StringIO(r'''t,E,j
             ... 0,0,0
             ... 1,1,1''')
-            >>> metadata = {'figure description': {'schema': {'fields': [{'name':'t', 'unit':'s'},{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'}]}}}
+            >>> metadata = {'figure description': {'fields': [{'name':'t', 'unit':'s'},{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'}]}}
             >>> csv = CSVloader(file=file)
-            >>> csv.derive_fields(fields=metadata['figure description']['schema']['fields'])
+            >>> csv.derive_fields(fields=metadata['figure description']['fields'])
             [{'name': 't', 'type': 'integer', 'unit': 's'}, {'name': 'E', 'type': 'integer', 'unit': 'V', 'reference': 'RHE'}, {'name': 'j', 'type': 'integer', 'unit': 'uA / cm2'}]
 
         When a field is missing (here `t`) it will be generated and all obsolete fields are removed.::
@@ -318,9 +318,9 @@ class CSVloader:
             >>> file = StringIO(r'''t,E,j
             ... 0,0,0
             ... 1,1,1''')
-            >>> metadata = {'figure description': {'schema': {'fields': [{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name': 'x'},{'foo':'bar'}]}}}
+            >>> metadata = {'figure description': {'fields': [{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name': 'x'},{'foo':'bar'}]}}
             >>> csv = CSVloader(file=file)
-            >>> csv.derive_fields(fields=metadata['figure description']['schema']['fields'])
+            >>> csv.derive_fields(fields=metadata['figure description']['fields'])
             [{'name': 't', 'type': 'integer'}, {'name': 'E', 'type': 'integer', 'unit': 'V', 'reference': 'RHE'}, {'name': 'j', 'type': 'integer', 'unit': 'uA / cm2'}]
 
         """

--- a/echemdbconverters/ec_unit_package_adapter.py
+++ b/echemdbconverters/ec_unit_package_adapter.py
@@ -11,8 +11,8 @@ EXAMPLES::
     ... 0,0,0,0
     ... 1,1,1,1''')
     >>> from echemdbconverters.csvloader import CSVloader
-    >>> metadata = {'figure description': {'schema': {'fields': [{'name':'t', 'unit':'s'},{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'x', 'unit':'m'}]}}}
-    >>> ec = ECUnitPackageAdapter(CSVloader(file=file), fields=metadata['figure description']['schema']['fields'])
+    >>> metadata = {'figure description': {'fields': [{'name':'t', 'unit':'s'},{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'x', 'unit':'m'}]}}
+    >>> ec = ECUnitPackageAdapter(CSVloader(file=file), fields=metadata['figure description']['fields'])
     >>> ec.df
        t  E  j  x
     0  0  0  0  0
@@ -67,8 +67,8 @@ class ECUnitPackageAdapter:
         ... 0,0,0,0
         ... 1,1,1,1''')
         >>> from echemdbconverters.csvloader import CSVloader
-        >>> metadata = {'figure description': {'schema': {'fields': [{'name':'t', 'unit':'s'},{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'x', 'unit':'m'}]}}}
-        >>> ec = ECUnitPackageAdapter(CSVloader(file=file), fields=metadata['figure description']['schema']['fields'])
+        >>> metadata = {'figure description': {'fields': [{'name':'t', 'unit':'s'},{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'x', 'unit':'m'}]}}
+        >>> ec = ECUnitPackageAdapter(CSVloader(file=file), fields=metadata['figure description']['fields'])
         >>> ec.df
            t  E  j  x
         0  0  0  0  0
@@ -105,8 +105,8 @@ class ECUnitPackageAdapter:
             ... 0,0,0,0
             ... 1,1,1,1''')
             >>> from echemdbconverters.csvloader import CSVloader
-            >>> metadata = {'figure description': {'schema': {'fields': [{'name':'t', 'unit':'s'},{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'x', 'unit':'m'}]}}}
-            >>> ec = ECUnitPackageAdapter.create('eclab')(CSVloader(file=file), fields=metadata['figure description']['schema']['fields'])
+            >>> metadata = {'figure description': {'fields': [{'name':'t', 'unit':'s'},{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'x', 'unit':'m'}]}}
+            >>> ec = ECUnitPackageAdapter.create('eclab')(CSVloader(file=file), fields=metadata['figure description']['fields'])
             >>> ec.df
             t  E  j  x
             0  0  0  0  0
@@ -160,8 +160,8 @@ class ECUnitPackageAdapter:
             ... 0,0,0,0
             ... 1,1,1,1''')
             >>> from echemdbconverters.csvloader import CSVloader
-            >>> metadata = {'figure description': {'schema': {'fields': [{'name':'t', 'unit':'s'},{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'x', 'unit':'m'}]}}}
-            >>> ec = ECUnitPackageAdapter(CSVloader(file=file), fields=metadata['figure description']['schema']['fields'])
+            >>> metadata = {'figure description': {'fields': [{'name':'t', 'unit':'s'},{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'x', 'unit':'m'}]}}
+            >>> ec = ECUnitPackageAdapter(CSVloader(file=file), fields=metadata['figure description']['fields'])
             >>> ec.fields() # doctest: +NORMALIZE_WHITESPACE
             [{'name': 't', 'type': 'integer', 'unit': 's'},
             {'name': 'E', 'type': 'integer', 'unit': 'V', 'reference': 'RHE'},
@@ -175,8 +175,8 @@ class ECUnitPackageAdapter:
             ... 0,0,0,0
             ... 1,1,1,1''')
             >>> from echemdbconverters.csvloader import CSVloader
-            >>> metadata = {'figure description': {'schema': {'fields': [{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'t', 'unit':'s'}]}}}
-            >>> ec = ECUnitPackageAdapter(CSVloader(file=file), fields=metadata['figure description']['schema']['fields'])
+            >>> metadata = {'figure description': {'fields': [{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'t', 'unit':'s'}]}}
+            >>> ec = ECUnitPackageAdapter(CSVloader(file=file), fields=metadata['figure description']['fields'])
             >>> ec.fields() # doctest: +NORMALIZE_WHITESPACE
             [{'name': 't', 'type': 'integer', 'unit': 's'},
             {'name': 'E', 'type': 'integer', 'unit': 'V', 'reference': 'RHE'},
@@ -190,8 +190,8 @@ class ECUnitPackageAdapter:
             ... 0,0,0
             ... 1,1,1''')
             >>> from echemdbconverters.csvloader import CSVloader
-            >>> metadata = {'figure description': {'schema': {'fields': [{'name':'t', 'unit':'s'},{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'}]}}}
-            >>> ec = ECUnitPackageAdapter(CSVloader(file=file), fields=metadata['figure description']['schema']['fields'])
+            >>> metadata = {'figure description': {'fields': [{'name':'t', 'unit':'s'},{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'}]}}
+            >>> ec = ECUnitPackageAdapter(CSVloader(file=file), fields=metadata['figure description']['fields'])
             >>> ec.fields()
             Traceback (most recent call last):
             ...
@@ -205,8 +205,8 @@ class ECUnitPackageAdapter:
             ... 0,0,0,0
             ... 1,1,1,1''')
             >>> from echemdbconverters.csvloader import CSVloader
-            >>> metadata = {'figure description': {'schema': {'fields': [{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'t'}]}}}
-            >>> ec = ECUnitPackageAdapter(CSVloader(file=file), fields=metadata['figure description']['schema']['fields'])
+            >>> metadata = {'figure description': {'fields': [{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'t'}]}}
+            >>> ec = ECUnitPackageAdapter(CSVloader(file=file), fields=metadata['figure description']['fields'])
             >>> ec.fields()
             Traceback (most recent call last):
             ...
@@ -254,8 +254,8 @@ class ECUnitPackageAdapter:
             ... 0,0,0,0
             ... 1,1,1,1''')
             >>> from echemdbconverters.csvloader import CSVloader
-            >>> metadata = {'figure description': {'schema': {'fields': [{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'x', 'unit':'m'},{'name':'t', 'unit':'s'}]}}}
-            >>> ec = ECUnitPackageAdapter(CSVloader(file), fields=metadata['figure description']['schema']['fields'])
+            >>> metadata = {'figure description': {'fields': [{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'x', 'unit':'m'},{'name':'t', 'unit':'s'}]}}
+            >>> ec = ECUnitPackageAdapter(CSVloader(file), fields=metadata['figure description']['fields'])
             >>> ec.column_names
             ['t', 'E', 'j', 'x']
 
@@ -274,8 +274,8 @@ class ECUnitPackageAdapter:
             ... 0,0,0,0
             ... 1,1,1,1''')
             >>> from echemdbconverters.csvloader import CSVloader
-            >>> metadata = {'figure description': {'schema': {'fields': [{'name':'t', 'unit':'s'},{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'x', 'unit':'m'}]}}}
-            >>> ec = ECUnitPackageAdapter(CSVloader(file), fields=metadata['figure description']['schema']['fields'])
+            >>> metadata = {'figure description': {'fields': [{'name':'t', 'unit':'s'},{'name':'E', 'unit':'V', 'reference':'RHE'},{'name':'j', 'unit':'uA / cm2'},{'name':'x', 'unit':'m'}]}}
+            >>> ec = ECUnitPackageAdapter(CSVloader(file), fields=metadata['figure description']['fields'])
             >>> ec.df
                t  E  j  x
             0  0  0  0  0

--- a/echemdbconverters/entrypoint.py
+++ b/echemdbconverters/entrypoint.py
@@ -197,7 +197,7 @@ def convert(csv, device, outdir, metadata):
     if metadata:
         metadata = yaml.load(metadata, Loader=yaml.SafeLoader)
         try:
-            fields = metadata["figure description"]["schema"]["fields"]
+            fields = metadata["figure description"]["fields"]
         except (KeyError, AttributeError):
             logger.warning("No units to the fields provided in the metadata")
 
@@ -280,7 +280,7 @@ def electrochemistry(csv, device, outdir, metadata):
     if metadata:
         metadata = yaml.load(metadata, Loader=yaml.SafeLoader)
         try:
-            fields = metadata["figure description"]["schema"]["fields"]
+            fields = metadata["figure description"]["fields"]
         except (KeyError, AttributeError):
             logger.warning("No units to the fields provided in the metadata")
 

--- a/test/csv/eclab_cv_csv.mpt.metadata
+++ b/test/csv/eclab_cv_csv.mpt.metadata
@@ -112,8 +112,8 @@ curation:
   version: 1
   process:
   - role: experimentalist
-    name: Tobias Schmider
-    orcid: https://orcid.org/0000-0002-2911-2925
+    name: Max Doe
+    orcid: https://orcid.org/0000-0002-9686-3948
     date: 2022-04-05
 time metadata: '2022-04-05T09:25:25'
 measurement file name: 2022-04-05_DCP2_TOSC_000_PTSC4_HClO4_CO_03_CV_C01.mpt

--- a/test/csv/eclab_cv_ec.mpt.metadata
+++ b/test/csv/eclab_cv_ec.mpt.metadata
@@ -112,8 +112,8 @@ curation:
   version: 1
   process:
   - role: experimentalist
-    name: Tobias Schmider
-    orcid: https://orcid.org/0000-0002-2911-2925
+    name: Max Doe
+    orcid: https://orcid.org/0000-0002-9686-3948
     date: 2022-04-05
 time metadata: '2022-04-05T09:25:25'
 measurement file name: 2022-04-05_DCP2_TOSC_000_PTSC4_HClO4_CO_03_CV_C01.mpt

--- a/test/csv/unit.csv.metadata
+++ b/test/csv/unit.csv.metadata
@@ -1,10 +1,9 @@
 figure description:
-    schema:
-        fields:
-          - name: E
-            unit: U
-            reference: RHE
-          - name: j
-            unit: uA / cm2
-          - name: t
-            unit: s
+  fields:
+    - name: E
+      unit: U
+      reference: RHE
+    - name: j
+      unit: uA / cm2
+    - name: t
+      unit: s

--- a/test/generated/eclab_cv_csv.json.expected
+++ b/test/generated/eclab_cv_csv.json.expected
@@ -247,8 +247,8 @@
                         "process": [
                             {
                                 "role": "experimentalist",
-                                "name": "Tobias Schmider",
-                                "orcid": "https://orcid.org/0000-0002-2911-2925",
+                                "name": "Max Doe",
+                                "orcid": "https://orcid.org/0000-0002-9686-3948",
                                 "date": "2022-04-05"
                             }
                         ]

--- a/test/generated/eclab_cv_ec.json.expected
+++ b/test/generated/eclab_cv_ec.json.expected
@@ -250,8 +250,8 @@
                         "process": [
                             {
                                 "role": "experimentalist",
-                                "name": "Tobias Schmider",
-                                "orcid": "https://orcid.org/0000-0002-2911-2925",
+                                "name": "Max Doe",
+                                "orcid": "https://orcid.org/0000-0002-9686-3948",
                                 "date": "2022-04-05"
                             }
                         ]

--- a/test/generated/unit.json.expected
+++ b/test/generated/unit.json.expected
@@ -31,23 +31,21 @@
             "metadata": {
                 "echemdb": {
                     "figure description": {
-                        "schema": {
-                            "fields": [
-                                {
-                                    "name": "E",
-                                    "unit": "U",
-                                    "reference": "RHE"
-                                },
-                                {
-                                    "name": "j",
-                                    "unit": "uA / cm2"
-                                },
-                                {
-                                    "name": "t",
-                                    "unit": "s"
-                                }
-                            ]
-                        }
+                        "fields": [
+                            {
+                                "name": "E",
+                                "unit": "U",
+                                "reference": "RHE"
+                            },
+                            {
+                                "name": "j",
+                                "unit": "uA / cm2"
+                            },
+                            {
+                                "name": "t",
+                                "unit": "s"
+                            }
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
Infer the fields from the metadata from a different level in the CLI. Examples have been adapter.

Fields should be nested in the metadata file under `figure_description.fields' instead of `figure_description.schema.fields'